### PR TITLE
Add elixir syntax highlighting to standalone ecto blog post

### DIFF
--- a/source/posts/2016-08-17-using-ecto-2-without-phoenix-but-with-tests.html.md
+++ b/source/posts/2016-08-17-using-ecto-2-without-phoenix-but-with-tests.html.md
@@ -23,23 +23,23 @@ cd todos
 
 Add Ecto and Postgres (assuming Postgres) to mix.exs dependencies and application to _mix.exs_.
 
-```
-  def application do
-    [applications: [:logger, :ecto, :postgrex],
-     mod: {Todos, []}]
-  end
+```elixir
+def application do
+  [applications: [:logger, :ecto, :postgrex],
+    mod: {Todos, []}]
+end
 
-  defp deps do
-    [
-      {:ecto, "~> 2.0.4"},
-      {:postgrex, ">= 0.0.0"},
-    ]
-  end
+defp deps do
+  [
+    {:ecto, "~> 2.0.4"},
+    {:postgrex, ">= 0.0.0"},
+  ]
+end
 ```
 
 We need to create our Repo ourselves. Make the file _lib/todos/repo.ex_ with the following content.
 
-```
+```elixir
 defmodule Todos.Repo do
   use Ecto.Repo, otp_app: :todos
 end
@@ -47,22 +47,22 @@ end
 
 A _Repo_ is a Supervisor; we need to add it to our application's supervision tree. In _lib/todos.ex_ add to the application supervisor.
 
-```
-  def start(_type, _args) do
-    import Supervisor.Spec, warn: false
+```elixir
+def start(_type, _args) do
+  import Supervisor.Spec, warn: false
 
-    children = [
-      supervisor(Todos.Repo, []), # <--- Add this line
-    ]
+  children = [
+    supervisor(Todos.Repo, []), # <--- Add this line
+  ]
 
-    opts = [strategy: :one_for_one, name: Todos.Supervisor]
-    Supervisor.start_link(children, opts)
-  end
+  opts = [strategy: :one_for_one, name: Todos.Supervisor]
+  Supervisor.start_link(children, opts)
+end
 ```
 
 The _Repo_ will be looking for configuration. Let's put our development config in _config/dev.exs_. I'm using the same assumptions as Phoenix: that there's a dev database server on localhost with a super-user called 'postgres' with an easy-to-guess password.
 
-```
+```elixir
 use Mix.Config
 
 config :todos, Todos.Repo,[
@@ -76,7 +76,7 @@ config :todos, Todos.Repo,[
 
 We'll need to ensure that `dev.exs` is compiled by including it in `config/config.exs`. While we're in that file we will configure the `Mix tasks` to use the correct Repo.
 
-```
+```elixir
 config :todos, :ecto_repos, [Todos.Repo] # Required for Mix tasks, such as mix ecto.gen.migration
 
 import_config "#{Mix.env}.exs" # Should just need to uncomment this line
@@ -91,14 +91,14 @@ mix ecto.create
 
 Now let's add our _todos_ table, to hold our "to do" list.
 
-```
+```elixir
 mix ecto.gen.migration AddTodos
 ```
 
 This will create the directories _priv/repo/migrations/_. Within migrations edit file called _[timestamp]_add_todos.exs, to create the table.
 
 
-```
+```elixir
 defmodule Todos.Repo.Migrations.AddTodos do
   use Ecto.Migration
 
@@ -116,7 +116,7 @@ end
 We'll also want to create the schema that maps to the table. My preference is to follow the boilerplate used by _Phoenix Ecto_. Let's create the file _lib/todos/todo.ex_
 
 
-```
+```elixir
 defmodule Todos.Todo do
   use Ecto.Schema
   import Ecto.Changeset
@@ -169,7 +169,7 @@ iex(3)>
 
 Now we are ready to add some functionality and, of course, some tests. As I've been cheerfully ignoring Michael Feather's [definition of unit tests](http://www.artima.com/weblogs/viewpost.jsp?thread=126923) since 2005, let's set up the test database. Add _config/test.exs_
 
-```
+```elixir
 use Mix.Config
 
 config :todos, Todos.Repo,[
@@ -191,14 +191,14 @@ MIX_ENV=test mix ecto.migrate
 
 We want to use the `Repo` in Sandbox mode, so that we can take run concurrent tests, and also be sure that database changes are transient. Add to the bottom of `test/test_helper.exs`
 
-```
+```elixir
 ExUnit.start()
 Ecto.Adapters.SQL.Sandbox.mode(Todos.Repo, :manual)
 ```
 
 Let's write a test in _test/todos/todo_items_test.exs_
 
-```
+```elixir
 defmodule Todos.TodoItemsTest do
   alias Todos.TodoItems
   use ExUnit.Case
@@ -216,7 +216,7 @@ end
 
 The test will fail, because we have not written an implementation. Let's do that in `lib/todos/todo_items.ex`.
 
-```
+```elixir
 defmodule Todos.TodoItems do
   alias Todos.{Repo, Todo}
   import Ecto.Query
@@ -258,10 +258,11 @@ It fails. But happily it tells us exactly why it fails:
 
 
 We need to checkout the repo, before running the test. Add to `test/todos/todo_items_test.ex`
-```
-  setup do
-    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
-  end
+
+```elixir
+setup do
+  :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+end
 ```
 
 It all passes! Hooray. You are up to [here](https://github.com/CultivateHQ/ecto_todos/tree/without-process) in the example repository.


### PR DESCRIPTION
Noticed this when reading through this morning - our syntax highlighter has support for elixir (and we use it in the phoenix/elm post series).

This also cleans the indentation so it is consistent across all the examples - can revert that if needed.