### PR TITLE
Use careers@ email address on /jobs/data too

### DIFF
--- a/source/jobs/data.html.md
+++ b/source/jobs/data.html.md
@@ -8,12 +8,12 @@ layout: "job"
 
 ## Source of Candidate Data
 
-Currently we do not collect data from anyone other than the candidate. A candidate will only appear in our recruitment systems by initially emailing `jobs@cultivatehq.com`.
+Currently we do not collect data from anyone other than the candidate. A candidate will only appear in our recruitment systems by initially emailing `careers@cultivatehq.com`.
 
 
 ## Data storage
 
-Emails to`jobs@cultivatehq.com` are received by all staff members in their [Google GSuite Mailbox](https://gsuite.google.com). Typically emails are archived but never deleted.
+Emails to`careers@cultivatehq.com` are received by all staff members in their [Google GSuite Mailbox](https://gsuite.google.com). Typically emails are archived but never deleted.
 
 Those emails are also received by a custom recruitment [Trello](https://trello.com) board. Each candidate is represented by a single card on that board. The board is used to track a candidate's progress through our recruitment process. Subsequent emails and notes on conversations are added to this card.
 
@@ -23,9 +23,9 @@ An unsuccessful candidate's Trello card is deleted one year after the last recru
 
 ## Erasure procedure
 
-Should a candidate wish to be erased from our system, they should get in touch via [jobs@cultivatehq.com](mailto:jobs@cultivatehq.com). They should tell us of the email addresses that they have used to communicate with us. We will
+Should a candidate wish to be erased from our system, they should get in touch via [careers@cultivatehq.com](mailto:careers@cultivatehq.com). They should tell us of the email addresses that they have used to communicate with us. We will
 
 * Instruct current staff members to search and delete all emails to and from that candidate from their company email account
-* Delete the candidate's Trello account
+* Delete the candidate's Trello card
 
 Note that staff members who leave Cultivate have their Cultivate email deleted.


### PR DESCRIPTION
From a candidate's email:

> Sending to both careers and jobs@cultivatehq.com because they are different in https://cultivatehq.com/jobs/ and https://cultivatehq.com/jobs/data/.
